### PR TITLE
Update to fix HTTP endpoints

### DIFF
--- a/backend/dist/src/main/resources/application.properties
+++ b/backend/dist/src/main/resources/application.properties
@@ -15,12 +15,12 @@ quarkus.hibernate-orm.database.generation=drop-and-create
 quarkus.resteasy.path=/api
 
 quarkus.http.cors=true
-quarkus.http.cors.origins=http://localhost:3000
+quarkus.http.cors.origins=https://localhost:3000
 quarkus.http.cors.headers=origin,content-type,accept,Authorization,Access-Control-Allow-Headers,Access-Control-Request-Method
 quarkus.http.cors.methods=GET, POST, PUT, DELETE, OPTIONS, HEAD, PATCH
 
 # OIDC Configuration
-quarkus.oidc.auth-server-url=http://0.0.0.0:8180/auth/realms/SmartHome
+quarkus.oidc.auth-server-url=https://0.0.0.0:8180/auth/realms/SmartHome
 quarkus.oidc.client-id=smartHome-backend
 quarkus.keycloak.policy-enforcer.lazy-load-paths=true
 quarkus.oidc.connection-delay=600S


### PR DESCRIPTION
Some of the endpoints are still using HTTP that is insecure ... replaced with secure HTTP (HTTP with SSL/TLS) that exists.  

Details:

I found instances where the HTTP protocol is used instead of HTTPS (HTTP with TLS). According to the Common Weakness Enumeration organization this is a security weakness (https://cwe.mitre.org/data/definitions/319.html).